### PR TITLE
Add MIT LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 measurement.js contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 #     MeasurementJs
 [![Code Climate](https://codeclimate.com/github/Philzen/measurement.js.png)](https://codeclimate.com/github/Philzen/measurement.js)
 [![Build Status](https://travis-ci.org/Philzen/measurement.js.svg?branch=0-1-stable)](https://travis-ci.org/Philzen/measurement.js)
-[![devDependency Status](https://david-dm.org/philzen/measurement.js/dev-status.svg?theme=shields.io)](https://david-dm.org/philzen/measurement.js#info=devDependencies) 
+[![devDependency Status](https://david-dm.org/philzen/measurement.js/dev-status.svg?theme=shields.io)](https://david-dm.org/philzen/measurement.js#info=devDependencies)
 
 
 Nice unit of measure conversion, featuring:
-- __Simplicity__: an easy to-use, Behaviour driven API 
+- __Simplicity__: an easy to-use, Behaviour driven API
 - __Sophistication__:  [![Coverage Status](https://coveralls.io/repos/Philzen/measurement.js/badge.png?branch=0-1-stable)](https://coveralls.io/r/Philzen/measurement.js?branch=0-1-stable) full test coverage from project day one
-- __Quality__: aiming at high performance whilst maintaining a fair trade-off between accuracy 
+- __Quality__: aiming at high performance whilst maintaining a fair trade-off between accuracy
 - __Adaptability__: Easy to extend for new measurement types (incl. i18n tables)
 
 
@@ -19,7 +19,7 @@ measurement('Temperature').convert(20)
 measurement('Distance').convert(1)
     .from(measurement.Unit.Distance.KILOMETRE)
     .to(measurement.Unit.Distance.METRE);                // returns 1000
-    
+
 measurement('Speed').convert(10)
     .from(measurement.Unit.Speed.KILOMETRE_PER_HOUR)
     .to(measurement.Unit.Speed.METRE_PER_SECOND);       // returns 2.7777777777777777
@@ -28,14 +28,14 @@ measurement('Speed').convert(10)
 
 ### Test-Driven Development
 
-The API definition and all conversion operations are covered by jasmine tests. 
+The API definition and all conversion operations are covered by jasmine tests.
 The test suite can be executed straightaway and easily, for example:
 
 - Option 1: Test directly in the browser
 Simply open test/index.html in the browser
 
-- Option 2: Headless Testing via Karma test driver  
-`npm run-script karma`  
+- Option 2: Headless Testing via Karma test driver
+`npm run-script karma`
 Above is just a shorthand for `node_modules/.bin/karma start`. If you have
 `karma-cli` already installed globally, you can also just do `karma start`.
 Karma will startup and run all tests on phantomjs
@@ -69,6 +69,9 @@ Please feel free to add your own test results.
     Chrome 18.0.1025 (Linux): Executed 46 of 46 SUCCESS (0.06 secs / 0.035 secs)
     Firefox 28.0.0 (Ubuntu): Executed 46 of 46 SUCCESS (0.037 secs / 0.026 secs)
 
+### License
+
+Distributable under the terms of the [MIT license](LICENSE.md)
 
 ### Inspiring projects
 


### PR DESCRIPTION
@Philzen @hyperlink

Fixes #5

The project is marked as MIT license here:
https://github.com/Philzen/measurement.js/blob/587018eb512dcf320beeb0b18c795f180e7c38a1/package.json#L11

This adds the `LICENSE.md` file and updates the `README.md` to include a reference to it.
