### PR TITLE
mJsNamespace is created if it does not already exist

### DIFF
--- a/measurement.js
+++ b/measurement.js
@@ -401,4 +401,4 @@
         win.module.exports.measurementjs = mjs;
     }
 
-})(window, window.mJsNamespace);
+})(window, (window.mJsNamespace || window.mJsNamespace = {}));


### PR DESCRIPTION
mJsNamespace is now created if it does not already exist, when passed to the IIFE which provides scope to the entire module.